### PR TITLE
Implement snap packaging, Snaps are universal Linux packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Snap packaging specific rules
+/snap/.snapcraft/
+/parts/
+/stage/
+/prime/
+
+/*.snap
+/*_source.tar.bz2

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Configure hook to set up configuration when `snap set` is called
+# 林博仁(Buo-ren, Lin) © 2019
+
+set \
+    -o errexit \
+    -o errtrace \
+    -o nounset \
+    -o pipefail
+
+init(){
+    local \
+        document_root_dir \
+        listening_port \
+        enable_access_log
+
+    document_root_dir="$(snapctl get document-root-dir)"
+    listening_port="$(snapctl get listening-port)"
+    enable_access_log="$(snapctl get enable-access-log)"
+
+    if test -n "${document_root_dir}"; then
+        if ! ls "${document_root_dir}" >/dev/null; then
+            printf -- \
+                'configure: Error: document-root-dir is not accessible, ensure you have connect the security confinement interface that allows the access.\n' \
+                >&2
+            exit 1
+        fi
+    else
+        snapctl set document-root-dir="${SNAP_COMMON}"
+    fi
+
+    if test -n "${listening_port}"; then
+        # https://en.wikipedia.org/wiki/Port_(computer_networking)#Port_number
+        if test "${listening_port}" -ge 1 \
+            && test "${listening_port}" -le 65535; then
+            :
+        else
+            printf -- \
+                'configure: Error: listening-port must be a number between 1~65535.\n' \
+                >&2
+            exit 1
+        fi
+    else
+        snapctl set listening-port=80
+    fi
+
+    if test -n "${enable_access_log}"; then
+        if test "${enable_access_log}" != false \
+            && test "${enable_access_log}" != true; then
+            # Markdown <code> backticks are not bash command expansions
+            # shellcheck disable=SC2016
+            printf -- \
+                'configure: Error: enable-access-log must be `true` or `false`.\n' \
+                >&2
+            exit 1
+        fi
+    else
+        snapctl set enable-access-log=false
+    fi
+    exit 0
+}
+
+init "${@}"

--- a/snap/local/launchers/uhttpd-launch
+++ b/snap/local/launchers/uhttpd-launch
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# This is the maintainence launcher for the snap, make necessary runtime
+# environment changes to make the snap work here.  You may also insert
+# security confinement/deprecation/obsoletion notice of the snap here.
+
+set \
+    -o errexit \
+    -o errtrace \
+    -o nounset \
+    -o pipefail
+
+declare \
+    document_root_dir \
+    document_root_dir_default \
+    listening_port \
+    listening_part_default=80 \
+    enable_access_log \
+    enable_access_log_default=false
+
+document_root_dir="$(snapctl get document-root-dir)"
+document_root_dir_default="${SNAP_COMMON}"
+listening_port="$(snapctl get listening-port)"
+enable_access_log="$(snapctl get enable-access-log)"
+
+"${SNAP}"/bin/uhttpd \
+    -addr=":${listening_port:-${listening_part_default}}" \
+    -dir="${document_root_dir:-${document_root_dir_default}}" \
+    -log="${enable_access_log:-${enable_access_log_default}}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,110 @@
+%YAML 1.1
+---
+# Snapcraft Recipe for uhttpd
+# ------------------------------
+# This file is in the YAML data serialization format:
+# http://yaml.org
+# For the spec. of writing this file refer the following documentation:
+# * The snapcraft format
+#   https://docs.snapcraft.io/the-snapcraft-format/8337
+# * Snap Documentation
+#   https://docs.snapcraft.io
+# * Topics under the doc category in the Snapcraft Forum
+#   https://forum.snapcraft.io/c/doc
+# For support refer to the snapcraft section in the Snapcraft Forum:
+# https://forum.snapcraft.io/c/snapcraft
+name: uhttpd
+title: uhttpd
+summary: A laughably-small HTTP server
+description: |
+  The only thing uhttpd is good for, is serving static content. It has no fancy bells, or whistles, like virtual host, or CGI support. All it does is host static files out of a directory for you.
+
+  If you are looking for the [uhttpd][1] that ships with OpenWRT, you are in the wrong place.
+
+  [1]: https://wiki.openwrt.org/doc/howto/http.uhttpd
+
+  **Snap-specific Information**
+
+  Customize the listening port(Default: 80):
+
+      sudo snap set uhttpd listening-port=8080
+
+  Customize the serving directory(Default: /var/snap/uhttpd/common) (EXPERIMENTAL, likely won't work):
+
+      sudo snap set uhttpd document-root-dir=/media/USB
+
+  Toggle output of access logging(Default: false):
+
+      sudo snap set uhttpd enable-access-log=true
+
+license: MIT
+
+assumes:
+- command-chain
+adopt-info: uhttpd
+base: core
+confinement: strict
+grade: stable
+
+parts:
+  # Launcher to apply snap configuration and launch the service
+  launchers:
+    source: snap/local/launchers
+    plugin: dump
+    organize:
+      '*': bin/
+
+  # Check out the tagged release revision if it isn't promoted to the stable channel
+  # https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
+  selective-checkout:
+    plugin: nil
+    build-packages:
+    - git
+    stage-snaps:
+    - selective-checkout
+    prime:
+    - -*
+
+  uhttpd:
+    after:
+    - selective-checkout
+
+    source: https://github.com/nesv/uhttpd.git
+    override-pull: |
+      set -o nounset
+
+      snapcraftctl pull
+
+      "${SNAPCRAFT_STAGE}"/scriptlets/selective-checkout
+
+    plugin: go
+    go-importpath: github.com/nesv/uhttpd
+    build-packages:
+    - gcc
+
+    organize:
+      bin/uhttpd.git: bin/uhttpd
+
+apps:
+  uhttpd:
+    adapter: full
+    command: bin/uhttpd-launch
+    daemon: simple
+    environment:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+
+hooks:
+  configure:
+    plugs:
+    # We need to verify if the document root directory is accessible here
+    - home
+    - removable-media
+
+plugs:
+  # Regular file access (for hosting files under certain personal files path
+  home:
+  removable-media: # Non-A/C
+
+  # Acting as a server
+  network-bind:


### PR DESCRIPTION
This patch implements the necessary details to package uhttpd as a snap
that can be installed and run on numerous supported GNU/Linux
distributions and Ubuntu Core systems.

Refer-to: Snapcraft - Snaps are universal Linux packages
<https://snapcraft.io>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>